### PR TITLE
fix: UserCreateReq에는 닉네임만 보내고, 서버에서 나머지 필드를 기본값으로 처리, 프론트 api 연동도 수정

### DIFF
--- a/backend/src/main/java/com/snaptale/backend/user/model/UserCreateReq.java
+++ b/backend/src/main/java/com/snaptale/backend/user/model/UserCreateReq.java
@@ -3,9 +3,5 @@ package com.snaptale.backend.user.model;
 import java.time.LocalDateTime;
 
 public record UserCreateReq(
-        String nickname,
-        Integer rankPoint,
-        Integer matchesPlayed,
-        Integer wins,
-        LocalDateTime lastSeen) {
+        String nickname) {
 }

--- a/backend/src/main/java/com/snaptale/backend/user/service/UserService.java
+++ b/backend/src/main/java/com/snaptale/backend/user/service/UserService.java
@@ -12,7 +12,7 @@ import com.snaptale.backend.user.entity.User;
 import com.snaptale.backend.user.model.UserCreateReq;
 import com.snaptale.backend.user.model.UserRes;
 import com.snaptale.backend.user.model.UserUpdateReq;
-
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -40,10 +40,10 @@ public class UserService {
     public UserRes createUser(UserCreateReq request) {
         User user = User.builder()
                 .nickname(request.nickname())
-                .rankPoint(request.rankPoint())
-                .matchesPlayed(request.matchesPlayed())
-                .wins(request.wins())
-                .lastSeen(request.lastSeen())
+                .rankPoint(0)
+                .matchesPlayed(0)
+                .wins(0)
+                .lastSeen(LocalDateTime.now())
                 .build();
         userRepository.save(user);
         return UserRes.from(user);

--- a/frontend/src/Components/Init/api/user.js
+++ b/frontend/src/Components/Init/api/user.js
@@ -2,12 +2,8 @@ export async function createUser(nickname) {
   const res = await fetch(`${import.meta.env.VITE_API_BASE}/api/users`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-     body: JSON.stringify({
+    body: JSON.stringify({
       nickname,
-      rankPoint: 0,
-      matchesPlayed: 0,
-      wins: 0,
-      lastSeen: new Date().toISOString()
     }),
   });
 


### PR DESCRIPTION
## 변경 사항
<!-- 
여기에 이번 PR에서 어떤 작업을 했는지 간단히 적어주세요.
예시: "회원가입 API 연동", "로그인 UI 수정"
-->
UserCreateReq에는 닉네임만 보내고, 서버에서 나머지 필드를 기본값으로 처리합니다.
프론트 api 연동도 변경된 사항에 맞춰 수정했습니다.

## 연관 이슈 번호
Closes #28


## 추가 확인 필요 사항 (선택)
<!-- 
아직 미완성 부분이나 리뷰어가 알아야 할 점이 있으면 적어주세요.
예시: "에러 메시지 디자인은 추후 수정 예정"
없으면 이 섹션은 삭제해도 괜찮습니다.
-->
