### PR TITLE
Implement game initialization and websocket join flow

### DIFF
--- a/backend/src/main/java/com/snaptale/backend/match/controller/MatchController.java
+++ b/backend/src/main/java/com/snaptale/backend/match/controller/MatchController.java
@@ -2,7 +2,6 @@ package com.snaptale.backend.match.controller;
 
 import java.util.List;
 
-import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -13,7 +12,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.util.StringUtils;
 import jakarta.validation.Valid;
+import com.snaptale.backend.common.exceptions.BaseException;
 import com.snaptale.backend.common.response.BaseResponse;
 import com.snaptale.backend.common.response.BaseResponseStatus;
 import com.snaptale.backend.match.model.request.MatchCreateReq;
@@ -107,9 +108,17 @@ public class MatchController {
     @PostMapping("/{matchId}/join")
     public BaseResponse<MatchJoinRes> joinMatch(
             @PathVariable Long matchId,
-            @Payload MatchJoinMessage message,
+            @RequestBody MatchJoinMessage message,
             SimpMessageHeaderAccessor headerAccessor) {
-        String sessionId = headerAccessor.getSessionId();
+        String sessionId = message.getSessionId();
+        if (!StringUtils.hasText(sessionId) && headerAccessor != null) {
+            sessionId = headerAccessor.getSessionId();
+        }
+
+        if (!StringUtils.hasText(sessionId)) {
+            throw new BaseException(BaseResponseStatus.BAD_REQUEST);
+        }
+
         message.setSessionId(sessionId);
         message.setMatchId(matchId);
         MatchJoinRes response = matchRESTService.joinMatch(message);

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,6 +5,7 @@ import  Home  from "./Components/Home/Home";
 import  DeckCheck from "./Components/DeckCheck/DeckCheck";
 import  GameLoading from "./Components/Home/GameLoading";
 import  GamePlay  from "./Components/GamePlay/Index";
+import { Navigate } from "react-router-dom";
 import  GameResult  from "./Components/GameResult";
 
 function App() {
@@ -21,7 +22,8 @@ function App() {
         {/* 게임 로딩 화면*/}
         <Route path="/gameloading" element={<GameLoading />} />
         {/* 게임 플레이 화면 */}
-        <Route path="/gameplay" element={<GamePlay />} />
+        <Route path="/gameplay" element={<Navigate to="/home" replace />} />
+        <Route path="/gameplay/:matchId" element={<GamePlay />} />
         {/* 게임 결과 확인 화면*/}
         <Route path="/gameresult" element={<GameResult />} />
       </Routes>

--- a/frontend/src/Components/GamePlay/Card.jsx
+++ b/frontend/src/Components/GamePlay/Card.jsx
@@ -26,30 +26,13 @@ const factionClasses = {
 };
 
 const Card = ({
-  cardId,
   name,
   imageUrl,
   cost,
   power,
   faction,
-  effectDesc,
-  active,
-  createdAt,
-  updatedAt,
-  onCardClick 
+  onCardClick
 }) => {
-  console.log({
-    cardId,
-    name,
-    imageUrl,
-    cost,
-    power,
-    faction,
-    effectDesc,
-    active,
-    createdAt,
-    updatedAt
-  });
     const ref = useRef(null);
     useEffect(() => {
       const el = ref.current;

--- a/frontend/src/Components/GamePlay/GameLayout.css
+++ b/frontend/src/Components/GamePlay/GameLayout.css
@@ -16,6 +16,20 @@
   align-items:center;
   padding: clamp(8px, 1.6vh, 12px) 0;
 }
+.connection-status {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+  color: #2d3748;
+  font-weight: 600;
+  font-size: clamp(12px, 2vw, 14px);
+}
+
+.connection-error {
+  color: #c62828;
+  font-size: clamp(11px, 1.8vw, 13px);
+}
 .exit-btn{
   background:#444;
   color:#fff;
@@ -37,13 +51,40 @@
   padding: 0 clamp(8px, 2vw, 12px) clamp(12px, 2vh, 16px);
 }
 
-.gl-oppo-chip{
-  padding:.35rem .9rem;
-  border-radius:10px;
-  background:#e7d9c4;
-  border:2px solid #7a4d2f;
-  font-weight:800;
-  box-shadow: inset 0 -2px #d3c4aa;
+.gl-scoreboard {
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: clamp(8px, 1.6vw, 16px);
+}
+
+.gl-score {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: clamp(10px, 1.8vw, 14px) clamp(12px, 2vw, 18px);
+  border-radius: 12px;
+  box-shadow: inset 0 -2px rgba(0,0,0,0.08);
+}
+
+.gl-score-opponent {
+  background: #f6e8da;
+  border: 2px solid #c49a71;
+}
+
+.gl-score-self {
+  background: #dbe8ff;
+  border: 2px solid #7aa0d6;
+}
+
+.gl-score-name {
+  font-weight: 700;
+  font-size: clamp(13px, 2.4vw, 16px);
+}
+
+.gl-score-value {
+  font-weight: 800;
+  font-size: clamp(16px, 2.8vw, 20px);
 }
 
 .gl-wrap .gl-lanes3{

--- a/frontend/src/Components/GamePlay/GameLayout.jsx
+++ b/frontend/src/Components/GamePlay/GameLayout.jsx
@@ -1,18 +1,53 @@
 // src/Components/GamePlay/GameLayout.jsx
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import "./GameLayout.css";
 import Card from "./Card";
 import EnlargedCard from "./EnlargedCard";
 import DCI from "../../assets/defaultCardImg.svg";
+import { useGame } from "../../contexts/GameContext.jsx";
 
 export default function GameLayout() {
-  const lanes = 3;                 // 왼/중/오
-  const topCountPerLane = 4;       // 위 4장
-  const botCountPerLane = 4;       // 아래 4장
-  const handCount = 12;            // 6x2
+  const lanes = 3;
+  const topCountPerLane = 4;
+  const botCountPerLane = 4;
+  const totalHandSlots = 12;
   const [selectedCard, setSelectedCard] = useState(null);
+  const { gameState } = useGame();
+
+  const participants = gameState?.participants;
+  const participantScores = gameState?.participantScores ?? [];
+  const myParticipantId = gameState?.currentUserParticipantId;
+
+  const participantList = useMemo(
+    () => Object.values(participants ?? {}),
+    [participants],
+  );
+
+  const myParticipant = myParticipantId && participants
+    ? participants[myParticipantId]
+    : null;
+
+  const opponentParticipant = useMemo(
+    () => participantList.find((participant) => participant.participantId !== myParticipantId),
+    [participantList, myParticipantId],
+  );
+
+  const myScore = participantScores.find((score) => score.participantId === myParticipantId);
+  const opponentScore = participantScores.find((score) => score.participantId === opponentParticipant?.participantId);
+
+  const handCards = useMemo(() => {
+    const cards = myParticipant?.handCards ?? [];
+    if (cards.length >= totalHandSlots) {
+      return cards.slice(0, totalHandSlots);
+    }
+    const placeholders = Array.from({ length: totalHandSlots - cards.length }, () => null);
+    return [...cards, ...placeholders];
+  }, [myParticipant?.handCards]);
 
   const handleCardClick = (cardData) => {
+    if (!cardData) {
+      return;
+    }
     setSelectedCard(cardData);
   };
 
@@ -20,84 +55,83 @@ export default function GameLayout() {
     setSelectedCard(null);
   };
 
-  // 샘플 카드 데이터 12장 (임의 생성)
-  const sampleCards = Array.from({ length: handCount }).map((_, i) => ({
-    cardId: `card-${i}`,
-    name: `Card ${i + 1}`,
-    imageUrl: DCI,
-    cost: Math.floor(Math.random() * 10) + 1,    // 1~10 랜덤
-    power: Math.floor(Math.random() * 10) + 1,   // 1~10 랜덤
-    faction: ["korea", "china", "japan"][i % 3], // 번갈아 korea, china, japan
-    effectDesc: "Sample effect description",
-    active: true,
-    createdAt: new Date().toISOString(),
-    updatedAt: new Date().toISOString()
-  }));
+  const renderCard = (card, index) => {
+    if (!card) {
+      return <div className="gl-card" key={`placeholder-${index}`} />;
+    }
+
+    return (
+      <Card
+        key={card.cardId}
+        cardId={card.cardId}
+        name={card.name}
+        imageUrl={card.imageUrl || DCI}
+        cost={card.cost}
+        power={card.power}
+        faction={card.faction}
+        effectDesc={card.effectDesc}
+        active={card.active}
+        createdAt={card.createdAt}
+        updatedAt={card.updatedAt}
+        onCardClick={() => handleCardClick(card)}
+      />
+    );
+  };
 
   return (
-  <div>
-    <div className="gl-wrap">
-      <div className="gl-oppo-chip">상대닉네임</div>
-
-      {/* 위 3레인 × 4장 */}
-      <section className="gl-lanes3">
-        {Array.from({ length: lanes }).map((_, laneIdx) => (
-          <div className="gl-laneCol" key={`top-${laneIdx}`}>
-            {Array.from({ length: topCountPerLane }).map((__, i) => (
-              <div className="gl-card" key={`t-${laneIdx}-${i}`} />
-            ))}
+    <div>
+      <div className="gl-wrap">
+        <div className="gl-scoreboard">
+          <div className="gl-score gl-score-opponent">
+            <span className="gl-score-name">{opponentScore?.nickname || opponentParticipant?.nickname || "상대"}</span>
+            <span className="gl-score-value">{opponentScore?.score ?? 0}</span>
           </div>
-        ))}
-      </section>
-
-      {/* 중앙 정육각 3개 */}
-      <section className="gl-hexRow">
-        {Array.from({ length: lanes }).map((_, i) => (
-          <div className="gl-hex" key={`hex-${i}`} />
-        ))}
-      </section>
-
-      {/* 아래 3레인 × 4장 */}
-      <section className="gl-lanes3">
-        {Array.from({ length: lanes }).map((_, laneIdx) => (
-          <div className="gl-laneCol" key={`bot-${laneIdx}`}>
-            {Array.from({ length: botCountPerLane }).map((__, i) => (
-              <div className="gl-card" key={`b-${laneIdx}-${i}`} />
-            ))}
+          <div className="gl-score gl-score-self">
+            <span className="gl-score-name">{myScore?.nickname || myParticipant?.nickname || "나"}</span>
+            <span className="gl-score-value">{myScore?.score ?? 0}</span>
           </div>
-        ))}
-      </section>
+        </div>
 
-      <div className="gl-turnOrb">1</div>
+        <section className="gl-lanes3">
+          {Array.from({ length: lanes }).map((_, laneIdx) => (
+            <div className="gl-laneCol" key={`top-${laneIdx}`}>
+              {Array.from({ length: topCountPerLane }).map((__, i) => (
+                <div className="gl-card" key={`t-${laneIdx}-${i}`} />
+              ))}
+            </div>
+          ))}
+        </section>
 
-      {/* 손패 6x2 = 12 */}
-      <section className="gl-hand12">
-        {sampleCards.map(card => (
-          <Card
-            key={card.cardId}
-            cardId={card.cardId}
-            name={card.name}
-            imageUrl={card.imageUrl}
-            cost={card.cost}
-            power={card.power}
-            faction={card.faction}
-            effectDesc={card.effectDesc}
-            active={card.active}
-            createdAt={card.createdAt}
-            updatedAt={card.updatedAt}
-            onCardClick={() => handleCardClick(card)}
-          />
-        ))}
-      </section>
-      <footer className="gl-footer">
-        <button className="gl-endBtn">턴 종료 (1/6)</button>
-      </footer>
-    </div>
+        <section className="gl-hexRow">
+          {Array.from({ length: lanes }).map((_, i) => (
+            <div className="gl-hex" key={`hex-${i}`} />
+          ))}
+        </section>
+
+        <section className="gl-lanes3">
+          {Array.from({ length: lanes }).map((_, laneIdx) => (
+            <div className="gl-laneCol" key={`bot-${laneIdx}`}>
+              {Array.from({ length: botCountPerLane }).map((__, i) => (
+                <div className="gl-card" key={`b-${laneIdx}-${i}`} />
+              ))}
+            </div>
+          ))}
+        </section>
+
+        <div className="gl-turnOrb">1</div>
+
+        <section className="gl-hand12">
+          {handCards.map((card, index) => renderCard(card, index))}
+        </section>
+        <footer className="gl-footer">
+          <button className="gl-endBtn" type="button">턴 종료 (1/6)</button>
+        </footer>
+      </div>
       {selectedCard && (
         <div className="modal-backdrop">
           <EnlargedCard card={selectedCard} onClose={handleCloseModal} />
         </div>
       )}
-  </div>
+    </div>
   );
 }

--- a/frontend/src/Components/GamePlay/Index.jsx
+++ b/frontend/src/Components/GamePlay/Index.jsx
@@ -1,18 +1,185 @@
-import { useNavigate } from "react-router-dom";
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
 import GameLayout from "./GameLayout";
 import Soundbar from "../Home/SoundIcon";
+import { useUser } from "../../contexts/UserContext.jsx";
+import { useGame } from "../../contexts/GameContext.jsx";
+import { buildWebSocketUrl, fetchCards, joinMatch } from "../../api/game.js";
+import { SimpleStompClient } from "../../lib/simpleStompClient.js";
+
+const STATUS_LABEL = {
+  connecting: "매치 서버에 연결 중...",
+  connected: "상대와 연결되었습니다.",
+  joining: "매치에 참가 중...",
+  ready: "매치 준비 완료!",
+  error: "연결에 실패했습니다.",
+};
 
 const GamePlay = () => {
   const navigate = useNavigate();
+  const { matchId: matchIdParam } = useParams();
+  const matchId = matchIdParam ? Number(matchIdParam) : null;
+  const { user } = useUser();
+  const {
+    gameState,
+    updateParticipantScores,
+    setParticipantHandCards,
+    setStompSessionId,
+    clearGame,
+  } = useGame();
+
+  const [connectionStatus, setConnectionStatus] = useState("connecting");
+  const [error, setError] = useState(null);
+
+  const myParticipant = useMemo(() => {
+    if (!gameState) return null;
+    return gameState.participants?.[gameState.currentUserParticipantId] ?? null;
+  }, [gameState]);
+
+  useEffect(() => {
+    return () => {
+      clearGame();
+    };
+  }, [clearGame]);
+
+  useEffect(() => {
+    if (!matchId || !gameState || gameState.matchId !== matchId) {
+      navigate("/home", { replace: true });
+    }
+  }, [gameState, matchId, navigate]);
+
+  useEffect(() => {
+    if (!gameState || !user || !matchId || gameState.matchId !== matchId) {
+      return undefined;
+    }
+
+    let isCancelled = false;
+    setConnectionStatus("connecting");
+    setError(null);
+
+    const client = new SimpleStompClient(buildWebSocketUrl());
+
+    let subscription = null;
+
+    client.onError((clientError) => {
+      if (isCancelled) {
+        return;
+      }
+      setError(clientError.message || "STOMP 연결 오류가 발생했습니다.");
+      setConnectionStatus("error");
+    });
+
+    client.onClose(() => {
+      if (isCancelled) {
+        return;
+      }
+      setConnectionStatus((prev) => (prev === "error" ? prev : "connecting"));
+    });
+
+    client
+      .connect()
+      .then(async (frame) => {
+        if (isCancelled) {
+          return;
+        }
+
+        const sessionId = frame.headers.session;
+        setStompSessionId(sessionId);
+        setConnectionStatus("connected");
+
+        subscription = client.subscribe(`/topic/match/${matchId}`, (messageFrame) => {
+          try {
+            const payload = JSON.parse(messageFrame.body);
+            if (payload?.data?.participantScores) {
+              updateParticipantScores(payload.data.participantScores);
+            }
+          } catch (subscribeError) {
+            console.error("매치 업데이트 파싱 실패", subscribeError);
+          }
+        });
+
+        try {
+          setConnectionStatus("joining");
+          const response = await joinMatch(matchId, {
+            userId: user.guestId,
+            nickname: user.nickname,
+            sessionId,
+          });
+
+          if (response?.gameState?.participantScores) {
+            updateParticipantScores(response.gameState.participantScores);
+          }
+          setConnectionStatus("ready");
+        } catch (joinError) {
+          console.error(joinError);
+          setError(joinError.message || "매치 참가 중 오류가 발생했습니다.");
+          setConnectionStatus("error");
+        }
+      })
+      .catch((connectError) => {
+        if (isCancelled) {
+          return;
+        }
+        setError(connectError.message || "STOMP 연결에 실패했습니다.");
+        setConnectionStatus("error");
+      });
+
+    return () => {
+      isCancelled = true;
+      if (subscription) {
+        subscription.unsubscribe();
+      }
+      client.disconnect();
+    };
+  }, [gameState, matchId, setStompSessionId, updateParticipantScores, user]);
+
+  useEffect(() => {
+    if (!myParticipant || !myParticipant.handCardIds?.length || myParticipant.handCards) {
+      return undefined;
+    }
+
+    let cancelled = false;
+
+    async function loadHandCards() {
+      try {
+        const cards = await fetchCards(myParticipant.handCardIds);
+        if (!cancelled) {
+          setParticipantHandCards(myParticipant.participantId, cards);
+        }
+      } catch (fetchError) {
+        console.error(fetchError);
+      }
+    }
+
+    loadHandCards();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [myParticipant, setParticipantHandCards]);
+
+  const statusMessage = STATUS_LABEL[connectionStatus] ?? STATUS_LABEL.connecting;
+
+  if (!matchId || !gameState || gameState.matchId !== matchId) {
+    return null;
+  }
 
   return (
     <div className="gameplay-container">
       <header className="gameplay-header">
         <Soundbar />
-        <button 
+        <div className="connection-status">
+          <span>{statusMessage}</span>
+          {error && <span className="connection-error">{error}</span>}
+        </div>
+        <button
           className="exit-btn"
-          onClick={() => navigate("/home")}>
-            나가기
+          onClick={() => {
+            clearGame();
+            navigate("/home");
+          }}
+        >
+          나가기
         </button>
       </header>
       <GameLayout />

--- a/frontend/src/Components/Home/Modal.css
+++ b/frontend/src/Components/Home/Modal.css
@@ -97,7 +97,7 @@
     text-align: center;
     color: #FFFFFF;
 }
-.cancel{
+.cancel{ 
     background: #800000;
     margin-top: 71px;
     margin-left: 37px;
@@ -106,4 +106,41 @@
     background: #228B22;
     margin-top: 71px;
     margin-left: 157px;
+}
+
+.matched-player {
+    margin-top: 18px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+}
+
+.matched-player-avatar {
+    width: 54px;
+    height: 54px;
+    border-radius: 50%;
+    border: 2px solid rgba(0, 0, 0, 0.15);
+    object-fit: cover;
+}
+
+.matched-player-name {
+    font-size: 18px;
+    color: #ffffff;
+    text-shadow: -1px 0 #5B1B17, 0 1px #5B1B17, 1px 0 #5B1B17, 0 -1px #5B1B17;
+}
+
+.retry-button {
+    margin-top: 16px;
+    padding: 6px 12px;
+    border: none;
+    border-radius: 6px;
+    font-weight: 600;
+    cursor: pointer;
+    background: #f4b033;
+    color: #5b1b17;
+}
+
+.retry-button:hover {
+    background: #f7c45f;
 }

--- a/frontend/src/Components/Home/RDModal.jsx
+++ b/frontend/src/Components/Home/RDModal.jsx
@@ -1,60 +1,178 @@
-import './Modal.css'
-import MatchCode from './MatchCode';
-import profile1 from '../../assets/userProfile.png';
-import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
-{/* 전투 준비 중 모달창 */}
-const RDModal = ({setOpenRDModal, matchCode}) => {
-    const navigate = useNavigate(); 
-    //내 닉네임과 프로필을 받아오는 로직 구현 필요
-    const [isMatched, setIsMatched] = useState(false);
+import "./Modal.css";
+import MatchCode from "./MatchCode";
+import profile1 from "../../assets/userProfile.png";
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useUser } from "../../contexts/UserContext.jsx";
+import { useGame } from "../../contexts/GameContext.jsx";
+import { fetchDeckPresets, fetchUsers, initGame } from "../../api/game.js";
 
-     const [enemyPlayer, setEnemyPlayer] = useState({
-        userName: "",
-        profileImage: ""
-    });
-
-     useEffect(() => {
-        // 서버에서 매칭된 상대 유저 정보 받는 로직 (지금은 2초 뒤 설정)
-        const timer = setTimeout(() => {
-            setEnemyPlayer({
-                userName: "상대닉네임",
-                profileImage: profile1
-            });
-            setIsMatched(true);
-        }, 2000);
-
-        return () => clearTimeout(timer);
-    }, []);
-
-    useEffect(() => {
-        if (isMatched) {
-            navigate("/gameloading", {
-                state: {
-                    userName1: "내닉네임",
-                    profileImage1: profile1,
-                    userName2: enemyPlayer.userName,
-                    profileImage2: enemyPlayer.profileImage
-                }
-            });
-        }
-    }, [isMatched, navigate, enemyPlayer]);
-
-    return (
-        <div className = "Overlay">
-            <button className = "cancelIcon"
-                onClick={() => {
-                    setOpenRDModal(false); // 클릭하면 모달창 닫기
-                }}></button>
-            <div className = "modal-main">
-                {!isMatched ? (
-                    <>
-                        {matchCode && <MatchCode matchCode={matchCode} />}
-                        <span className="modal-text">전투 준비 중...</span>
-                    </>
-                ) : null}
-            </div>
-        </div>
-    );
+const STATUS = {
+  IDLE: "idle",
+  MATCHING: "matching",
+  READY: "ready",
+  ERROR: "error",
 };
+
+const RDModal = ({ setOpenRDModal, matchCode }) => {
+  const navigate = useNavigate();
+  const { user } = useUser();
+  const { setInitialGameState, clearGame } = useGame();
+  const [status, setStatus] = useState(STATUS.IDLE);
+  const [enemyPlayer, setEnemyPlayer] = useState(null);
+  const [error, setError] = useState(null);
+  const [retryToken, setRetryToken] = useState(0);
+
+  const statusLabel = useMemo(() => {
+    switch (status) {
+      case STATUS.MATCHING:
+        return "상대를 찾는 중입니다...";
+      case STATUS.READY:
+        return "매칭 완료!";
+      case STATUS.ERROR:
+        return error ?? "매칭 중 문제가 발생했습니다.";
+      default:
+        return "전투 준비 중...";
+    }
+  }, [status, error]);
+
+  useEffect(() => {
+    if (!user) {
+      setStatus(STATUS.ERROR);
+      setError("사용자 정보를 찾을 수 없습니다.");
+      return;
+    }
+
+    let isCancelled = false;
+
+    async function startMatching() {
+      try {
+        setStatus(STATUS.MATCHING);
+
+        const [users, deckPresets] = await Promise.all([
+          fetchUsers(),
+          fetchDeckPresets(),
+        ]);
+
+        if (isCancelled) {
+          return;
+        }
+
+        const candidates = users.filter((candidate) => candidate.guestId !== user.guestId);
+
+        if (candidates.length === 0) {
+          throw new Error("매칭 가능한 상대를 찾지 못했습니다.");
+        }
+
+        const opponent = candidates[Math.floor(Math.random() * candidates.length)];
+        setEnemyPlayer({
+          userName: opponent.nickname,
+          profileImage: profile1,
+          guestId: opponent.guestId,
+        });
+
+        const activeDecks = deckPresets
+          .filter((deck) => deck.active !== 0 && deck.cards?.length)
+          .map((deck) => deck.deckPresetId);
+
+        if (activeDecks.length < 2) {
+          throw new Error("사용 가능한 덱이 부족합니다.");
+        }
+
+        const shuffledDecks = [...activeDecks].sort(() => Math.random() - 0.5);
+        const [deck1Id, deck2Id] = [shuffledDecks[0], shuffledDecks.find((deckId) => deckId !== shuffledDecks[0])];
+
+        if (!deck1Id || !deck2Id) {
+          throw new Error("두 플레이어에게 배정할 덱을 찾을 수 없습니다.");
+        }
+
+        const initResult = await initGame({
+          player1Id: user.guestId,
+          player2Id: opponent.guestId,
+          deck1Id,
+          deck2Id,
+        });
+
+        if (isCancelled) {
+          return;
+        }
+
+        setInitialGameState({
+          matchId: initResult.matchId,
+          locations: initResult.locationIds,
+          currentUserParticipantId: initResult.participant1Id,
+          participants: {
+            [initResult.participant1Id]: {
+              participantId: initResult.participant1Id,
+              userId: user.guestId,
+              nickname: user.nickname,
+              deckId: deck1Id,
+              handCardIds: initResult.player1HandCardIds,
+            },
+            [initResult.participant2Id]: {
+              participantId: initResult.participant2Id,
+              userId: opponent.guestId,
+              nickname: opponent.nickname,
+              deckId: deck2Id,
+              handCardIds: initResult.player2HandCardIds,
+            },
+          },
+        });
+
+        setStatus(STATUS.READY);
+        setOpenRDModal(false);
+        navigate(`/gameplay/${initResult.matchId}`);
+      } catch (err) {
+        if (isCancelled) {
+          return;
+        }
+        setError(err.message || "매칭에 실패했습니다.");
+        setStatus(STATUS.ERROR);
+      }
+    }
+
+    startMatching();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [navigate, retryToken, setInitialGameState, setOpenRDModal, user]);
+
+  return (
+    <div className="Overlay">
+      <button
+        className="cancelIcon"
+        onClick={() => {
+          clearGame();
+          setOpenRDModal(false);
+        }}
+        aria-label="매칭 취소"
+      />
+      <div className="modal-main">
+        {matchCode && <MatchCode matchCode={matchCode} />}
+        <span className="modal-text">{statusLabel}</span>
+        {enemyPlayer && status !== STATUS.ERROR && (
+          <div className="matched-player">
+            <img src={enemyPlayer.profileImage} alt="상대 프로필" className="matched-player-avatar" />
+            <span className="matched-player-name">{enemyPlayer.userName}</span>
+          </div>
+        )}
+        {status === STATUS.ERROR && (
+          <button
+            className="retry-button"
+            onClick={() => {
+              setStatus(STATUS.IDLE);
+              setError(null);
+              setEnemyPlayer(null);
+              setRetryToken((prev) => prev + 1);
+            }}
+          >
+            다시 시도
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
 export default RDModal;

--- a/frontend/src/Components/Init/api/user.js
+++ b/frontend/src/Components/Init/api/user.js
@@ -2,7 +2,7 @@ const API_BASE = import.meta.env.VITE_API_BASE;
 
 async function parseJsonResponse(res) {
   if (!res.ok) {
-    const body = await res.text();
+    await res.text().catch(() => {});
     throw new Error(`HTTP ${res.status}`);
   }
 

--- a/frontend/src/api/game.js
+++ b/frontend/src/api/game.js
@@ -1,0 +1,76 @@
+const API_BASE = import.meta.env.VITE_API_BASE;
+
+async function handleResponse(response) {
+  if (!response.ok) {
+    const message = `${response.status} ${response.statusText}`;
+    throw new Error(message);
+  }
+
+  const data = await response.json();
+
+  if (!data.success) {
+    throw new Error(data.message || "요청에 실패했습니다.");
+  }
+
+  return data.result;
+}
+
+export async function fetchUsers() {
+  const res = await fetch(`${API_BASE}/api/users`, {
+    credentials: "include",
+  });
+
+  return handleResponse(res);
+}
+
+export async function fetchDeckPresets() {
+  const res = await fetch(`${API_BASE}/api/deck-presets`, {
+    credentials: "include",
+  });
+
+  return handleResponse(res);
+}
+
+export async function initGame(payload) {
+  const res = await fetch(`${API_BASE}/api/game/init`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+    body: JSON.stringify(payload),
+  });
+
+  return handleResponse(res);
+}
+
+export async function joinMatch(matchId, payload) {
+  const res = await fetch(`${API_BASE}/api/matches/${matchId}/join`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+    body: JSON.stringify(payload),
+  });
+
+  return handleResponse(res);
+}
+
+export async function fetchCard(cardId) {
+  const res = await fetch(`${API_BASE}/api/cards/${cardId}`, {
+    credentials: "include",
+  });
+
+  return handleResponse(res);
+}
+
+export async function fetchCards(cardIds) {
+  return Promise.all(cardIds.map((cardId) => fetchCard(cardId)));
+}
+
+export function buildWebSocketUrl(base = API_BASE) {
+  const url = new URL(base);
+  const protocol = url.protocol === "https:" ? "wss:" : "ws:";
+  return `${protocol}//${url.host}/ws-stomp/websocket`;
+}

--- a/frontend/src/contexts/GameContext.jsx
+++ b/frontend/src/contexts/GameContext.jsx
@@ -1,0 +1,117 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useCallback, useContext, useMemo, useReducer } from "react";
+
+const GameContext = createContext(null);
+
+const initialState = {
+  matchId: null,
+  participants: {},
+  locations: [],
+  participantScores: [],
+  currentUserParticipantId: null,
+  stompSessionId: null,
+};
+
+function gameReducer(state, action) {
+  switch (action.type) {
+    case "SET_INITIAL_STATE": {
+      const { matchId, participants, locations, currentUserParticipantId } = action.payload;
+      return {
+        matchId,
+        participants,
+        locations: locations ?? [],
+        participantScores: Object.values(participants).map((participant) => ({
+          participantId: participant.participantId,
+          nickname: participant.nickname,
+          score: 0,
+          remainingCards: participant.remainingCards ?? participant.handCardIds?.length ?? 0,
+        })),
+        currentUserParticipantId: currentUserParticipantId ?? null,
+        stompSessionId: null,
+      };
+    }
+    case "SET_PARTICIPANT_HAND": {
+      const { participantId, handCards } = action.payload;
+      if (!state.participants[participantId]) {
+        return state;
+      }
+      return {
+        ...state,
+        participants: {
+          ...state.participants,
+          [participantId]: {
+            ...state.participants[participantId],
+            handCards,
+          },
+        },
+      };
+    }
+    case "UPDATE_SCORES": {
+      return {
+        ...state,
+        participantScores: action.payload ?? [],
+      };
+    }
+    case "SET_STOMP_SESSION": {
+      return {
+        ...state,
+        stompSessionId: action.payload ?? null,
+      };
+    }
+    case "CLEAR":
+      return initialState;
+    default:
+      return state;
+  }
+}
+
+export function GameProvider({ children }) {
+  const [state, dispatch] = useReducer(gameReducer, initialState);
+
+  const setInitialGameState = useCallback((payload) => {
+    dispatch({ type: "SET_INITIAL_STATE", payload });
+  }, []);
+
+  const setParticipantHandCards = useCallback((participantId, handCards) => {
+    dispatch({
+      type: "SET_PARTICIPANT_HAND",
+      payload: { participantId, handCards },
+    });
+  }, []);
+
+  const updateParticipantScores = useCallback((scores) => {
+    dispatch({ type: "UPDATE_SCORES", payload: scores });
+  }, []);
+
+  const setStompSessionId = useCallback((sessionId) => {
+    dispatch({ type: "SET_STOMP_SESSION", payload: sessionId });
+  }, []);
+
+  const clearGame = useCallback(() => {
+    dispatch({ type: "CLEAR" });
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      gameState: state,
+      setInitialGameState,
+      setParticipantHandCards,
+      updateParticipantScores,
+      setStompSessionId,
+      clearGame,
+    }),
+    [state, setInitialGameState, setParticipantHandCards, updateParticipantScores, setStompSessionId, clearGame],
+  );
+
+  return <GameContext.Provider value={value}>{children}</GameContext.Provider>;
+}
+
+export function useGame() {
+  const context = useContext(GameContext);
+
+  if (!context) {
+    throw new Error("useGame must be used within a GameProvider");
+  }
+
+  return context;
+}

--- a/frontend/src/contexts/UserContext.jsx
+++ b/frontend/src/contexts/UserContext.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import { createContext, useCallback, useContext, useMemo, useState } from "react";
 
 const UserContext = createContext(null);

--- a/frontend/src/lib/simpleStompClient.js
+++ b/frontend/src/lib/simpleStompClient.js
@@ -1,0 +1,179 @@
+const TERMINATOR = "\u0000";
+
+function buildFrame(command, headers = {}, body = "") {
+  const headerLines = Object.entries(headers)
+    .filter(([, value]) => value !== undefined && value !== null)
+    .map(([key, value]) => `${key}:${value}`);
+
+  return `${command}\n${headerLines.join("\n")}\n\n${body}${TERMINATOR}`;
+}
+
+function parseFrame(rawFrame) {
+  const sanitized = rawFrame.replace(/\r/g, "");
+  const segments = sanitized.split("\n");
+  const command = segments.shift();
+
+  const headers = {};
+  let line = segments.shift();
+  while (line !== undefined && line !== "") {
+    const separatorIndex = line.indexOf(":");
+    if (separatorIndex > -1) {
+      const key = line.slice(0, separatorIndex).trim();
+      const value = line.slice(separatorIndex + 1).trim();
+      headers[key] = value;
+    }
+    line = segments.shift();
+  }
+
+  const body = segments.join("\n");
+  return { command, headers, body };
+}
+
+function splitFrames(payload) {
+  return payload
+    .split(TERMINATOR)
+    .map((frame) => frame.trim())
+    .filter((frame) => frame.length > 0);
+}
+
+export class SimpleStompClient {
+  constructor(url) {
+    this.url = url;
+    this.ws = null;
+    this.subscriptions = new Map();
+    this.subscriptionCounter = 0;
+    this.onConnectCallbacks = [];
+    this.onErrorCallbacks = [];
+    this.onCloseCallbacks = [];
+    this.connected = false;
+    this.sessionId = null;
+  }
+
+  connect(headers = {}) {
+    if (this.ws) {
+      return Promise.resolve();
+    }
+
+    return new Promise((resolve, reject) => {
+      this.ws = new WebSocket(this.url, ["v12.stomp", "v11.stomp", "v10.stomp"]);
+
+      this.ws.onopen = () => {
+        let hostHeader;
+        try {
+          hostHeader = new URL(this.url).host;
+        } catch {
+          hostHeader = undefined;
+        }
+        const frame = buildFrame(
+          "CONNECT",
+          {
+            "accept-version": "1.2,1.1,1.0",
+            "heart-beat": "10000,10000",
+            host: hostHeader,
+            ...headers,
+          },
+        );
+        this.ws.send(frame);
+      };
+
+      this.ws.onmessage = (event) => {
+        const frames = splitFrames(event.data);
+        frames.forEach((frameRaw) => {
+          const frame = parseFrame(frameRaw);
+
+          if (frame.command === "CONNECTED") {
+            this.connected = true;
+            this.sessionId = frame.headers.session;
+            resolve(frame);
+            this.onConnectCallbacks.forEach((callback) => callback(frame));
+            return;
+          }
+
+          if (frame.command === "MESSAGE") {
+            const subscriptionId = frame.headers.subscription;
+            const handler = this.subscriptions.get(subscriptionId);
+            if (handler) {
+              handler(frame);
+            }
+            return;
+          }
+
+          if (frame.command === "ERROR") {
+            const error = new Error(frame.body || "STOMP error");
+            this.onErrorCallbacks.forEach((callback) => callback(error));
+            reject(error);
+          }
+        });
+      };
+
+      this.ws.onerror = (error) => {
+        const err = error instanceof Event ? new Error("WebSocket error") : error;
+        this.onErrorCallbacks.forEach((callback) => callback(err));
+        reject(err);
+      };
+
+      this.ws.onclose = (event) => {
+        this.connected = false;
+        this.sessionId = null;
+        this.subscriptions.clear();
+        this.ws = null;
+        this.onCloseCallbacks.forEach((callback) => callback(event));
+      };
+    });
+  }
+
+  subscribe(destination, callback, headers = {}) {
+    if (!this.connected || !this.ws) {
+      throw new Error("STOMP client is not connected");
+    }
+
+    const id = headers.id || `sub-${++this.subscriptionCounter}`;
+    this.subscriptions.set(id, callback);
+    const frame = buildFrame("SUBSCRIBE", {
+      id,
+      destination,
+      ack: "auto",
+      ...headers,
+    });
+    this.ws.send(frame);
+
+    return {
+      unsubscribe: () => {
+        if (!this.ws) {
+          return;
+        }
+        this.ws.send(buildFrame("UNSUBSCRIBE", { id }));
+        this.subscriptions.delete(id);
+      },
+    };
+  }
+
+  disconnect() {
+    if (!this.ws) {
+      return;
+    }
+    try {
+      if (this.connected) {
+        this.ws.send(buildFrame("DISCONNECT"));
+      }
+      this.ws.close();
+    } finally {
+      this.ws = null;
+      this.connected = false;
+      this.sessionId = null;
+      this.subscriptions.clear();
+    }
+  }
+
+  onConnect(callback) {
+    this.onConnectCallbacks.push(callback);
+  }
+
+  onError(callback) {
+    this.onErrorCallbacks.push(callback);
+  }
+
+  onClose(callback) {
+    this.onCloseCallbacks.push(callback);
+  }
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -3,11 +3,14 @@ import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.jsx";
 import { UserProvider } from "./contexts/UserContext.jsx";
+import { GameProvider } from "./contexts/GameContext.jsx";
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>
     <UserProvider>
-      <App />
+      <GameProvider>
+        <App />
+      </GameProvider>
     </UserProvider>
   </StrictMode>
 );


### PR DESCRIPTION
## Summary
- require REST match join requests to provide a STOMP session id before registering participants
- add frontend game state context, API helpers, and a lightweight STOMP client to initialise matches and keep WebSocket updates in sync
- refresh the gameplay UI to surface connection status, player scores, and the real starting hand after random matchmaking

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_69009f96372c832e94cbb7c8f05acf3c