### PR TITLE
fix: layout clamp값 삭제, GameLayout PC, Mobile 파일만 생성

### DIFF
--- a/frontend/src/Components/GamePlay/Card.css
+++ b/frontend/src/Components/GamePlay/Card.css
@@ -1,24 +1,24 @@
 .card-container {
   position: relative;
-  width: clamp(2.1rem, 5.4vw, 3.4rem);
-  aspect-ratio: 2 / 3;
+  width: 54px;
+  height: 81px;
   cursor: grab;
   transition: transform 0.25s ease, box-shadow 0.25s ease;
 }
 
 .card-container:hover {
-  transform: translateY(clamp(-0.15rem, -0.5vw, -0.25rem)) scale(1.03);
-  box-shadow: 0 clamp(0.5rem, 2vw, 1.4rem) clamp(1.2rem, 3.4vw, 2.2rem) rgba(0, 0, 0, 0.35);
+  transform: translateY(-4px) scale(1.03);
+  box-shadow: 0 22px 35px rgba(0, 0, 0, 0.35);
 }
 
 .card-image {
   position: absolute;
-  inset: clamp(0.1rem, 0.32vw, 0.22rem);
-  border: clamp(0.1rem, 0.28vw, 0.18rem) solid transparent;
-  border-radius: clamp(0.26rem, 0.68vw, 0.42rem);
+  inset: 3.5px;
+  border: 3px solid transparent;
+  border-radius: 7px;
   object-fit: cover;
-  width: calc(100% - clamp(0.24rem, 0.76vw, 0.44rem));
-  height: calc(100% - clamp(0.24rem, 0.76vw, 0.44rem));
+  width: calc(100% - 7px);
+  height: calc(100% - 7px);
   z-index: 1;
 }
 
@@ -29,8 +29,8 @@
 
 /* 아이콘 공통 스타일 */
 .icon {
-  width: clamp(0.76rem, 1.9vw, 1.15rem);
-  height: clamp(0.76rem, 1.9vw, 1.15rem);
+  width: 18px;
+  height: 18px;
   display: block;
   position: relative;
   z-index: 3;
@@ -43,25 +43,25 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: clamp(0.76rem, 1.9vw, 1.12rem);
-  height: clamp(0.76rem, 1.9vw, 1.12rem);
+  width: 18px;
+  height: 18px;
   z-index: 5;
-  filter: drop-shadow(0 0 clamp(0.18rem, 0.5vw, 0.3rem) rgba(0, 0, 0, 0.55));
+  filter: drop-shadow(0 0 5px rgba(0, 0, 0, 0.55));
 }
 
 .card-cost-container {
-  top: clamp(0.1rem, 0.32vw, 0.2rem);
-  left: clamp(0.1rem, 0.32vw, 0.2rem);
+   top: 3px;
+  left: 3px;
 }
 
 .card-power-container {
-  top: clamp(0.1rem, 0.32vw, 0.2rem);
-  right: clamp(0.1rem, 0.32vw, 0.2rem);
+  top: 3px;
+  right: 3px;
 }
 
 .icon-text {
   position: absolute;
-  font-size: clamp(0.54rem, 1.3vw, 0.74rem);
+  font-size: 12px;
   color: #ffffff;
   user-select: none;
   pointer-events: none;
@@ -69,71 +69,71 @@
   left: 50%;
   transform: translate(-50%, -50%);
   z-index: 10;
-  text-shadow: 0 0 clamp(0.22rem, 0.7vw, 0.42rem) rgba(0, 0, 0, 0.45);
+  text-shadow: 0 0 6px rgba(0, 0, 0, 0.45);
 }
 
 .card-name {
   position: absolute;
   width: 72%;
-  min-height: clamp(0.72rem, 1.8vw, 0.94rem);
+  min-height: 15px;
   left: 50%;
-  bottom: clamp(0.16rem, 0.46vw, 0.28rem);
+  bottom: 4px;
   transform: translateX(-50%);
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: clamp(0.5rem, 1.18vw, 0.7rem);
+  font-size: 11px;
   color: #ffffff;
   z-index: 6;
   text-align: center;
   line-height: 1.12;
-  text-shadow: 0 0 clamp(0.2rem, 0.62vw, 0.36rem) rgba(0, 0, 0, 0.6);
-  padding-inline: clamp(0.16rem, 0.46vw, 0.26rem);
+  text-shadow: 0 0 6px rgba(0, 0, 0, 0.6);
+  padding-inline: 4px;
 }
 
 .enlarged-card-container {
   position: relative;
-  width: clamp(10.5rem, 28vw, 13rem);
-  aspect-ratio: 2 / 3;
+  width: 208px;
+  height: 312px;
   animation: zoomIn 0.3s ease-out;
 }
 
 .enlarged-card-container .card-image {
-  inset: clamp(0.4rem, 1vw, 0.6rem);
-  border-width: clamp(0.3rem, 0.9vw, 0.55rem);
-  border-radius: clamp(0.8rem, 2vw, 1.2rem);
-  width: calc(100% - clamp(0.8rem, 2vw, 1.2rem));
-  height: calc(100% - clamp(0.8rem, 2vw, 1.2rem));
+  inset: 10px;
+  border-width: 9px;
+  border-radius: 19px;
+  width: calc(100% - 38px);
+  height: calc(100% - 38px);
 }
 
 .enlarged-card-container .card-cost-container,
 .enlarged-card-container .card-power-container,
 .enlarged-card-container .icon {
-  width: clamp(2.7rem, 6.4vw, 3.3rem);
-  height: clamp(2.7rem, 6.4vw, 3.3rem);
+  width: 53px;
+  height: 53px;
 }
 
 .enlarged-card-container .card-cost-container,
 .enlarged-card-container .card-power-container {
-  top: clamp(-0.35rem, -0.8vw, -0.15rem);
+  top: -2px;
 }
 
 .enlarged-card-container .icon-text {
-  font-size: clamp(1.5rem, 3.4vw, 1.9rem);
+  font-size: 30px;
 }
 
 .enlarged-card-container .card-name {
   width: 80%;
-  font-size: clamp(1.2rem, 3vw, 1.6rem);
+  font-size: 26px;
 }
 
 .enlarged-card-container .card-desc {
   position: absolute;
-  width: clamp(12rem, 32vw, 16rem);
+  width: 256px;
   left: 50%;
-  bottom: clamp(-4.2rem, -12vw, -2.8rem);
+  bottom: -45px;
   transform: translateX(-50%);
-  font-size: clamp(1rem, 2.6vw, 1.4rem);
+  font-size: 22px;
   color: #ffecde;
   z-index: 6;
   text-align: center;
@@ -148,8 +148,8 @@
 /* Animated outline (top -> right -> bottom -> left). Total reveal time = 0.6s */
 .card-outline {
   position: absolute;
-  width: clamp(2.1rem, 5.4vw, 3.4rem);
-  aspect-ratio: 2 / 3;
+  width: 54px;
+  height: 81px;
   pointer-events: none;
   z-index: 20;
 }
@@ -161,7 +161,7 @@
 
 /* border thickness (consistent with design) */
 .card-outline span {
-  --bw: clamp(0.09rem, 0.25vw, 0.16rem);
+  --bw: 3px;
 }
 
 .card-outline .outline-top {
@@ -223,5 +223,108 @@
   to {
     transform: scale(1);
     opacity: 1;
+  }
+}
+
+@media (max-width: 767px) {
+  .card-container {
+    width: 34px;
+    height: 51px;
+  }
+
+  .card-container:hover {
+    transform: translateY(-2px) scale(1.03);
+    box-shadow: 0 8px 19px rgba(0, 0, 0, 0.35);
+  }
+
+  .card-image {
+    inset: 1.6px;
+    border: 2px solid transparent;
+    border-radius: 5px;
+    width: calc(100% - 4px);
+    height: calc(100% - 4px);
+  }
+
+  .icon {
+    width: 12px;
+    height: 12px;
+  }
+
+  .card-cost-container,
+  .card-power-container {
+    width: 12px;
+    height: 12px;
+    filter: drop-shadow(0 0 3px rgba(0, 0, 0, 0.55));
+  }
+
+  .card-cost-container {
+    top: 2px;
+    left: 2px;
+  }
+
+  .card-power-container {
+    top: 2px;
+    right: 2px;
+  }
+
+  .icon-text {
+    font-size: 9px;
+    text-shadow: 0 0 4px rgba(0, 0, 0, 0.45);
+  }
+
+  .card-name {
+    min-height: 12px;
+    bottom: 3px;
+    font-size: 8px;
+    text-shadow: 0 0 4px rgba(0, 0, 0, 0.6);
+    padding-inline: 3px;
+  }
+
+  .enlarged-card-container {
+    width: 168px;
+    height: 252px;
+  }
+
+  .enlarged-card-container .card-image {
+    inset: 6px;
+    border-width: 5px;
+    border-radius: 13px;
+    width: calc(100% - 26px);
+    height: calc(100% - 26px);
+  }
+
+  .enlarged-card-container .card-cost-container,
+  .enlarged-card-container .card-power-container,
+  .enlarged-card-container .icon {
+    width: 43px;
+    height: 43px;
+  }
+
+  .enlarged-card-container .card-cost-container,
+  .enlarged-card-container .card-power-container {
+    top: -6px;
+  }
+
+  .enlarged-card-container .icon-text {
+    font-size: 24px;
+  }
+
+  .enlarged-card-container .card-name {
+    font-size: 19px;
+  }
+
+  .enlarged-card-container .card-desc {
+    width: 192px;
+    bottom: -67px;
+    font-size: 16px;
+  }
+
+  .card-outline {
+    width: 34px;
+    height: 51px;
+  }
+
+  .card-outline span {
+    --bw: 2px;
   }
 }

--- a/frontend/src/Components/GamePlay/Energy.css
+++ b/frontend/src/Components/GamePlay/Energy.css
@@ -2,7 +2,7 @@
   position: relative;
   display: grid;
   place-items: center;
-  width: clamp(2.6rem, 5.4vw, 3.8rem);
+  width: 61px;
   aspect-ratio: 1;
   font-weight: 900;
   background: url("../../assets/energy.png") center/contain no-repeat;
@@ -15,8 +15,19 @@
 
 .energy-value {
   position: absolute;
-  font-size: clamp(0.95rem, 2.1vw, 1.45rem);
+  font-size: 23px;
   font-weight: 700;
   color: #2c1105;
-  text-shadow: 0 0 clamp(0.25rem, 0.8vw, 0.5rem) rgba(255, 255, 255, 0.95);
+  text-shadow: 0 0 8px rgba(255, 255, 255, 0.95);
+}
+
+@media (max-width: 767px) {
+  .energy {
+    width: 42px;
+  }
+
+  .energy-value {
+    font-size: 15px;
+    text-shadow: 0 0 4px rgba(255, 255, 255, 0.95);
+  }
 }

--- a/frontend/src/Components/GamePlay/GameLayoutDesktop.css
+++ b/frontend/src/Components/GamePlay/GameLayoutDesktop.css
@@ -1,0 +1,245 @@
+.gameplay-shell {
+  position: relative;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  min-height: 100dvh;
+  width: 100%;
+  color: #f7ede2;
+  overflow: hidden;
+  box-sizing: border-box;
+}
+
+.gameplay-shell .top-bar {
+  height: clamp(3.2rem, 6vw, 5rem);
+  padding: 0 clamp(1.25rem, 3vw, 2.75rem);
+}
+
+.gameplay-body {
+  display: flex;
+  align-items: stretch;
+  justify-content: flex-start;
+  gap: clamp(1.2rem, 2.6vw, 2.2rem);
+  padding: clamp(1.1rem, 3vh, 1.8rem) clamp(1rem, 2.6vw, 2.1rem);
+  padding-left: clamp(0.6rem, 1.6vw, 1.2rem);
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.hud-panel {
+  flex: 0 0 clamp(10.5rem, 16vw, 12.5rem);
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: flex-start;
+  gap: clamp(0.75rem, 1.8vw, 1.2rem);
+  padding: clamp(1rem, 2vw, 1.4rem) clamp(0.8rem, 1.8vw, 1.2rem);
+  border-radius: clamp(1rem, 2.4vw, 1.6rem);
+  background: linear-gradient(158deg, rgba(22, 13, 5, 0.46) 0%, rgba(22, 13, 5, 0.18) 100%);
+  box-shadow: 0 0 clamp(1.4rem, 3.4vw, 2.2rem) rgba(0, 0, 0, 0.24);
+  backdrop-filter: blur(6px);
+  box-sizing: border-box;
+  align-self: center;
+  height: auto;
+}
+
+.hud-section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(0.4rem, 1vw, 0.65rem);
+}
+
+.hud-section > * {
+  width: 100%;
+}
+
+.hud-matchup {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(0.45rem, 1.4vw, 0.9rem);
+  padding: clamp(0.7rem, 1.6vw, 1.1rem) clamp(0.4rem, 1.2vw, 0.7rem);
+  border-radius: clamp(0.9rem, 2.4vw, 1.5rem);
+  background: rgba(12, 7, 3, 0.52);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  min-height: clamp(7.5rem, 14vh, 9rem);
+  justify-content: center;
+}
+
+.hud-player {
+  display: block;
+  font-size: clamp(0.85rem, 1.8vw, 1.1rem);
+  font-weight: 700;
+  text-align: center;
+  line-height: 1.2;
+  word-break: keep-all;
+}
+
+.hud-player--opponent {
+  color: #ffb997;
+}
+
+.hud-player--me {
+  color: #9de2ff;
+}
+
+.hud-vs {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: clamp(0.75rem, 1.6vw, 0.95rem);
+  font-weight: 800;
+  color: #f7ede2;
+  padding: clamp(0.18rem, 0.52vw, 0.35rem) clamp(0.5rem, 1vw, 0.75rem);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.16);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.18);
+}
+
+.turn-panel {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(0.2rem, 0.6vw, 0.4rem);
+  letter-spacing: 0.05em;
+}
+
+.turn-panel__label {
+  font-size: clamp(0.68rem, 1.5vw, 0.88rem);
+  opacity: 0.75;
+}
+
+.turn-panel__value {
+  font-size: clamp(1.18rem, 2.8vw, 1.65rem);
+  font-weight: 700;
+}
+
+.turn-panel__max {
+  font-size: clamp(0.82rem, 2vw, 1.05rem);
+  font-weight: 500;
+  opacity: 0.7;
+}
+
+.end-turn-button {
+  width: clamp(4.4rem, 8.6vw, 6rem);
+  padding: clamp(0.5rem, 1.4vw, 0.85rem) clamp(0.9rem, 2vw, 1.25rem);
+  border-radius: clamp(0.8rem, 1.8vw, 1.2rem);
+  border: none;
+  color: #2c1105;
+  font-weight: 800;
+  font-size: clamp(0.9rem, 2.2vw, 1.15rem);
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: transform 0.2s ease, filter 0.2s ease;
+}
+
+.end-turn-button:hover {
+  transform: translateY(clamp(-0.08rem, -0.4vw, -0.18rem)) scale(1.03);
+  filter: brightness(1.05);
+}
+
+.end-turn-button:active {
+  transform: scale(0.98);
+}
+
+.end-turn-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  filter: grayscale(0.3);
+  transform: none;
+}
+
+.board-wrapper {
+  flex: 1 1 auto;
+  max-width: clamp(28rem, 78vw, 56rem);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(1.1rem, 3vh, 1.8rem);
+  padding: clamp(0.4rem, 1vw, 0.8rem) 0;
+  margin-left: clamp(1.4rem, 3vw, 2.6rem);
+}
+
+.board-grid {
+  width: min(100%, clamp(20rem, 74vw, 52rem));
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, clamp(6rem, 18vw, 9.2rem)));
+  grid-auto-rows: auto;
+  column-gap: clamp(0.8rem, 2vw, 1.4rem);
+  row-gap: clamp(0.75rem, 2.2vw, 1.6rem);
+  justify-content: center;
+  align-content: center;
+}
+
+.board-cell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+}
+
+.board-cell--slot {
+  padding: clamp(0.1rem, 0.4vw, 0.25rem);
+}
+
+.board-cell--location {
+  padding: 0;
+}
+
+.board-message {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: clamp(0.55rem, 1.4vw, 0.9rem);
+  border-radius: clamp(0.8rem, 1.8vw, 1.2rem);
+  background: rgba(255, 255, 255, 0.08);
+  color: #f7ede2;
+  font-size: clamp(0.82rem, 1.8vw, 1rem);
+}
+
+.board-message--error {
+  background: rgba(206, 68, 47, 0.18);
+  color: #ffb9a7;
+}
+
+.board-message--full {
+  grid-column: 1 / -1;
+  min-height: clamp(3.5rem, 10vh, 5rem);
+}
+
+.hand-row {
+  width: min(100%, clamp(22rem, 80vw, 48rem));
+  display: flex;
+  justify-content: center;
+}
+
+.hand-grid {
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(clamp(2.4rem, 6.5vw, 3.4rem), 1fr));
+  gap: clamp(0.4rem, 1.2vw, 0.75rem);
+  justify-items: center;
+}
+
+.hand-card {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.hand-card:active .card-container {
+  transform: scale(0.96);
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}

--- a/frontend/src/Components/GamePlay/GameLayoutMobile.css
+++ b/frontend/src/Components/GamePlay/GameLayoutMobile.css
@@ -1,0 +1,245 @@
+.gameplay-shell {
+  position: relative;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  min-height: 100dvh;
+  width: 100%;
+  color: #f7ede2;
+  overflow: hidden;
+  box-sizing: border-box;
+}
+
+.gameplay-shell .top-bar {
+  height: clamp(3.2rem, 6vw, 5rem);
+  padding: 0 clamp(1.25rem, 3vw, 2.75rem);
+}
+
+.gameplay-body {
+  display: flex;
+  align-items: stretch;
+  justify-content: flex-start;
+  gap: clamp(1.2rem, 2.6vw, 2.2rem);
+  padding: clamp(1.1rem, 3vh, 1.8rem) clamp(1rem, 2.6vw, 2.1rem);
+  padding-left: clamp(0.6rem, 1.6vw, 1.2rem);
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.hud-panel {
+  flex: 0 0 clamp(10.5rem, 16vw, 12.5rem);
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: flex-start;
+  gap: clamp(0.75rem, 1.8vw, 1.2rem);
+  padding: clamp(1rem, 2vw, 1.4rem) clamp(0.8rem, 1.8vw, 1.2rem);
+  border-radius: clamp(1rem, 2.4vw, 1.6rem);
+  background: linear-gradient(158deg, rgba(22, 13, 5, 0.46) 0%, rgba(22, 13, 5, 0.18) 100%);
+  box-shadow: 0 0 clamp(1.4rem, 3.4vw, 2.2rem) rgba(0, 0, 0, 0.24);
+  backdrop-filter: blur(6px);
+  box-sizing: border-box;
+  align-self: center;
+  height: auto;
+}
+
+.hud-section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(0.4rem, 1vw, 0.65rem);
+}
+
+.hud-section > * {
+  width: 100%;
+}
+
+.hud-matchup {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(0.45rem, 1.4vw, 0.9rem);
+  padding: clamp(0.7rem, 1.6vw, 1.1rem) clamp(0.4rem, 1.2vw, 0.7rem);
+  border-radius: clamp(0.9rem, 2.4vw, 1.5rem);
+  background: rgba(12, 7, 3, 0.52);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  min-height: clamp(7.5rem, 14vh, 9rem);
+  justify-content: center;
+}
+
+.hud-player {
+  display: block;
+  font-size: clamp(0.85rem, 1.8vw, 1.1rem);
+  font-weight: 700;
+  text-align: center;
+  line-height: 1.2;
+  word-break: keep-all;
+}
+
+.hud-player--opponent {
+  color: #ffb997;
+}
+
+.hud-player--me {
+  color: #9de2ff;
+}
+
+.hud-vs {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: clamp(0.75rem, 1.6vw, 0.95rem);
+  font-weight: 800;
+  color: #f7ede2;
+  padding: clamp(0.18rem, 0.52vw, 0.35rem) clamp(0.5rem, 1vw, 0.75rem);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.16);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.18);
+}
+
+.turn-panel {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(0.2rem, 0.6vw, 0.4rem);
+  letter-spacing: 0.05em;
+}
+
+.turn-panel__label {
+  font-size: clamp(0.68rem, 1.5vw, 0.88rem);
+  opacity: 0.75;
+}
+
+.turn-panel__value {
+  font-size: clamp(1.18rem, 2.8vw, 1.65rem);
+  font-weight: 700;
+}
+
+.turn-panel__max {
+  font-size: clamp(0.82rem, 2vw, 1.05rem);
+  font-weight: 500;
+  opacity: 0.7;
+}
+
+.end-turn-button {
+  width: clamp(4.4rem, 8.6vw, 6rem);
+  padding: clamp(0.5rem, 1.4vw, 0.85rem) clamp(0.9rem, 2vw, 1.25rem);
+  border-radius: clamp(0.8rem, 1.8vw, 1.2rem);
+  border: none;
+  color: #2c1105;
+  font-weight: 800;
+  font-size: clamp(0.9rem, 2.2vw, 1.15rem);
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: transform 0.2s ease, filter 0.2s ease;
+}
+
+.end-turn-button:hover {
+  transform: translateY(clamp(-0.08rem, -0.4vw, -0.18rem)) scale(1.03);
+  filter: brightness(1.05);
+}
+
+.end-turn-button:active {
+  transform: scale(0.98);
+}
+
+.end-turn-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  filter: grayscale(0.3);
+  transform: none;
+}
+
+.board-wrapper {
+  flex: 1 1 auto;
+  max-width: clamp(28rem, 78vw, 56rem);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(1.1rem, 3vh, 1.8rem);
+  padding: clamp(0.4rem, 1vw, 0.8rem) 0;
+  margin-left: clamp(1.4rem, 3vw, 2.6rem);
+}
+
+.board-grid {
+  width: min(100%, clamp(20rem, 74vw, 52rem));
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, clamp(6rem, 18vw, 9.2rem)));
+  grid-auto-rows: auto;
+  column-gap: clamp(0.8rem, 2vw, 1.4rem);
+  row-gap: clamp(0.75rem, 2.2vw, 1.6rem);
+  justify-content: center;
+  align-content: center;
+}
+
+.board-cell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+}
+
+.board-cell--slot {
+  padding: clamp(0.1rem, 0.4vw, 0.25rem);
+}
+
+.board-cell--location {
+  padding: 0;
+}
+
+.board-message {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: clamp(0.55rem, 1.4vw, 0.9rem);
+  border-radius: clamp(0.8rem, 1.8vw, 1.2rem);
+  background: rgba(255, 255, 255, 0.08);
+  color: #f7ede2;
+  font-size: clamp(0.82rem, 1.8vw, 1rem);
+}
+
+.board-message--error {
+  background: rgba(206, 68, 47, 0.18);
+  color: #ffb9a7;
+}
+
+.board-message--full {
+  grid-column: 1 / -1;
+  min-height: clamp(3.5rem, 10vh, 5rem);
+}
+
+.hand-row {
+  width: min(100%, clamp(22rem, 80vw, 48rem));
+  display: flex;
+  justify-content: center;
+}
+
+.hand-grid {
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(clamp(2.4rem, 6.5vw, 3.4rem), 1fr));
+  gap: clamp(0.4rem, 1.2vw, 0.75rem);
+  justify-items: center;
+}
+
+.hand-card {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.hand-card:active .card-container {
+  transform: scale(0.96);
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}

--- a/frontend/src/Components/GamePlay/Location.css
+++ b/frontend/src/Components/GamePlay/Location.css
@@ -2,38 +2,21 @@
 .location-container {
   position: relative;
   cursor: pointer;
-  width: clamp(6rem, 17vw, 9rem);
+  width: 144px;
   aspect-ratio: 7 / 10;
   padding: 0;
-  border-radius: clamp(1.05rem, 2.4vw, 1.65rem);
+  border-radius: 26.4px;
   background: transparent;
   transition: transform 0.25s ease;
   will-change: transform;
-  filter: drop-shadow(
-      0 clamp(0.12rem, 0.32vw, 0.22rem)
-      clamp(0.45rem, 1.2vw, 0.68rem)
-      rgba(11, 8, 2, 0.32)
-    )
-    drop-shadow(
-      0 clamp(0.28rem, 0.75vw, 0.46rem)
-      clamp(0.65rem, 1.6vw, 0.92rem)
-      rgba(9, 5, 0, 0.18)
-    );
+  filter: drop-shadow(0 3.5px 10.9px rgba(11, 8, 2, 0.32))
+  drop-shadow(0 7.4px 14.7px rgba(9, 5, 0, 0.18));
   transition: filter 0.3s ease;
 }
 
 .location-container:hover {
-  transform: translate3d(0, clamp(-0.16rem, -0.45vw, -0.26rem), 0);
-  filter: drop-shadow(
-      0 clamp(0.35rem, 0.95vw, 0.58rem)
-      clamp(1.05rem, 2.6vw, 1.52rem)
-      rgba(14, 9, 2, 0.5)
-    )
-    drop-shadow(
-      0 clamp(0.18rem, 0.48vw, 0.3rem)
-      clamp(0.55rem, 1.4vw, 0.82rem)
-      rgba(0, 0, 0, 0.25)
-    );
+  transform: translate3d(0, -4.2px, 0);
+  filter: drop-shadow(0 9.2px 24.3px rgba(14, 9, 2, 0.5)) drop-shadow(0 7px 13.1px rgba(0, 0, 0, 0.25));
 }
 
 /* 배경 이미지 */
@@ -79,7 +62,7 @@
 .location-container::before {
   content: "";
   position: absolute;
-  inset: clamp(0.12rem, 0.32vw, 0.22rem);
+  inset: 3.5px;
   border-radius: inherit;
   background: linear-gradient(180deg, rgba(15, 9, 3, 0.45), rgba(15, 9, 3, 0));
   mix-blend-mode: multiply;
@@ -110,7 +93,7 @@
 
 .locked-overlay {
   position: absolute;
-  inset: clamp(0.35rem, 1vw, 0.7rem);
+  inset: 11.2px;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -118,15 +101,15 @@
   border-radius: inherit;
   color: #fff;
   text-align: center;
-  padding: clamp(0.5rem, 1.3vw, 0.85rem);
+  padding: 13.6px;
   z-index: 5;
 }
 
 .locked-text {
-  font-size: clamp(0.85rem, 2.2vw, 1.1rem);
+  font-size: 17.6px;
   font-weight: 600;
   line-height: 1.4;
-  text-shadow: 0 0 clamp(0.35rem, 1vw, 0.65rem) rgba(0, 0, 0, 0.45);
+  text-shadow: 0 0 10.4px rgba(0, 0, 0, 0.45);
 }
 
 /* 이름과 설명 */
@@ -134,31 +117,30 @@
   position: absolute;
   top: 40%;
   left: 50%;
-  width: clamp(5.6rem, 14vw, 7.6rem);
+  width: 121.6px;
   transform: translate(-50%, -50%);
-  font-size: clamp(0.86rem, 2vw, 1.16rem);
+  font-size: 18.6px;
   color: #fff;
   text-align: center;
   z-index: 5;
   pointer-events: none;
-  text-shadow: 0 0 clamp(0.35rem, 1vw, 0.6rem) rgba(0, 0, 0, 0.6);
-  line-height: 1.3;
-  padding-inline: clamp(0.3rem, 0.8vw, 0.5rem);
+  text-shadow: 0 0 9.6px rgba(0, 0, 0, 0.6);
+  padding-inline: 8px;
 }
 
 .location-desc {
   position: absolute;
   top: 67%;
   left: 50%;
-  width: clamp(5.8rem, 15vw, 8.4rem);
+  width: 134.4px;
   transform: translate(-50%, -50%);
-  font-size: clamp(0.52rem, 1.3vw, 0.82rem);
+  font-size: 13.1px;
   color: #f7ede2;
   z-index: 5;
   text-align: center;
   pointer-events: none;
   line-height: 1.35;
-  padding-inline: clamp(0.2rem, 0.5vw, 0.35rem);
+  padding-inline: 5.6px;
 }
 
 /* 파워 정보 */
@@ -174,36 +156,36 @@
 }
 
 .opponentPower-container {
-  top: clamp(0.2rem, 0.6vw, 0.45rem);
+  top: 7.2px;
   transform: translate(-50%, -50%);
 }
 
 .myPower-container {
-  bottom: clamp(0.2rem, 0.6vw, 0.45rem);
+  bottom: 7.2px;
   transform: translate(-50%, 50%);
 }
 
 .location-icon {
-  width: clamp(1.6rem, 3.6vw, 2.35rem);
-  height: clamp(1.6rem, 3.6vw, 2.35rem);
+  width: 37.6px;
+  height: 37.6px;
   position: relative;
 }
 
 .location-icon-text {
   position: absolute;
-  font-size: clamp(0.78rem, 2vw, 1.12rem);
+  font-size: 17.9px;
   color: #ffffff;
   user-select: none;
   pointer-events: none;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  text-shadow: 0 0 clamp(0.3rem, 1vw, 0.55rem) rgba(0, 0, 0, 0.45);
+  text-shadow: 0 0 8.8px rgba(0, 0, 0, 0.45);
 }
 
 .enlarged-location-container {
   position: relative;
-  width: clamp(12rem, 32vw, 16rem);
+  width: 256px;
   aspect-ratio: 7 / 10;
   animation: zoomIn 0.3s ease-out;
 }
@@ -214,22 +196,106 @@
 }
 
 .enlarged-location-container .location-name {
-  top: clamp(32%, 33%, 34%);
+  top: 34%;
   width: 100%;
-  font-size: clamp(1.8rem, 4vw, 2.4rem);
+  font-size: 38.4px;
 }
 
 .enlarged-location-container .location-desc {
-  top: clamp(60%, 58%, 56%);
-  width: clamp(12rem, 32vw, 18rem);
-  font-size: clamp(1.1rem, 2.6vw, 1.4rem);
+  top: 56%;
+  width: 288px;
+  font-size: 22.4px;
 }
 
 .enlarged-location-container .location-icon {
-  width: clamp(3.5rem, 7vw, 4.25rem);
-  height: clamp(3.5rem, 7vw, 4.25rem);
+  width: 68px;
+  height: 68px;
 }
 
 .enlarged-location-container .location-icon-text {
-  font-size: clamp(1.8rem, 4vw, 2.4rem);
+  font-size: 38.4px;
+}
+
+@media (max-width: 767px) {
+  .location-container {
+    width: 96px;
+    border-radius: 16.8px;
+    filter: drop-shadow(0 1.9px 7.2px rgba(11, 8, 2, 0.32))
+      drop-shadow(0 4.5px 10.4px rgba(9, 5, 0, 0.18));
+  }
+
+  .location-container:hover {
+    transform: translate3d(0, -2.6px, 0);
+    filter: drop-shadow(0 5.6px 16.8px rgba(14, 9, 2, 0.5))
+      drop-shadow(0 2.9px 8.8px rgba(0, 0, 0, 0.25));
+  }
+
+  .location-container::before {
+    inset: 1.9px;
+  }
+
+  .locked-overlay {
+    inset: 5.6px;
+    padding: 8px;
+  }
+
+  .locked-text {
+    font-size: 13.6px;
+    text-shadow: 0 0 5.6px rgba(0, 0, 0, 0.45);
+  }
+
+  .location-name {
+    width: 89.6px;
+    font-size: 13.8px;
+    text-shadow: 0 0 5.6px rgba(0, 0, 0, 0.6);
+    padding-inline: 4.8px;
+  }
+
+  .location-desc {
+    width: 92.8px;
+    font-size: 8.3px;
+    padding-inline: 3.2px;
+  }
+
+  .opponentPower-container {
+    top: 3.2px;
+  }
+
+  .myPower-container {
+    bottom: 3.2px;
+  }
+
+  .location-icon {
+    width: 25.6px;
+    height: 25.6px;
+  }
+
+  .location-icon-text {
+    font-size: 12.5px;
+    text-shadow: 0 0 4.8px rgba(0, 0, 0, 0.45);
+  }
+
+  .enlarged-location-container {
+    width: 192px;
+  }
+
+  .enlarged-location-container .location-name {
+    top: 32%;
+    font-size: 28.8px;
+  }
+
+  .enlarged-location-container .location-desc {
+    top: 60%;
+    width: 192px;
+    font-size: 17.6px;
+  }
+
+  .enlarged-location-container .location-icon {
+    width: 56px;
+    height: 56px;
+  }
+
+  .enlarged-location-container .location-icon-text {
+    font-size: 28.8px;
+  }
 }

--- a/frontend/src/Components/GamePlay/Slot.css
+++ b/frontend/src/Components/GamePlay/Slot.css
@@ -4,16 +4,16 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: clamp(6.1rem, 17vw, 9.4rem);
-  min-height: clamp(6.3rem, 19vw, 10rem);
-  padding: clamp(0.45rem, 1.2vw, 0.9rem);
-  border-radius: clamp(0.95rem, 2.2vw, 1.5rem);
+  width: 150.4px;
+  min-height: 160px;
+  padding: 14.4px;
+  border-radius: 24px;
   background: linear-gradient(160deg, rgba(34, 24, 16, 0.72), rgba(34, 24, 16, 0.45)) padding-box,
     radial-gradient(circle at top, rgba(255, 198, 140, 0.35), transparent 65%) border-box;
-  border: clamp(0.12rem, 0.32vw, 0.2rem) solid rgba(194, 144, 101, 0.55);
+  border: 3.2px solid rgba(194, 144, 101, 0.55);
   box-shadow:
-    inset 0 0 clamp(0.48rem, 1.4vw, 1rem) rgba(0, 0, 0, 0.32),
-    0 clamp(0.35rem, 1vw, 0.75rem) clamp(1.1rem, 2.4vw, 1.8rem) rgba(0, 0, 0, 0.26);
+    inset 0 0 16px rgba(0, 0, 0, 0.32),
+    0 12px 28.8px rgba(0, 0, 0, 0.26);
   transition: box-shadow 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
   backdrop-filter: blur(2px);
   overflow: hidden;
@@ -24,8 +24,8 @@
 }
 
 .slot.is-ally.is-over {
-  box-shadow: 0 0 clamp(1rem, 3vw, 2.5rem) rgba(211, 196, 170, 0.35);
-  transform: translateY(clamp(-0.12rem, -0.4vw, -0.22rem));
+  box-shadow: 0 0 40px rgba(211, 196, 170, 0.35);
+  transform: translateY(-3.5px);
 }
 
 .slot.is-enemy {
@@ -42,7 +42,7 @@
 .slot__grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: clamp(0.34rem, 0.9vw, 0.62rem);
+  gap: 9.9px;
   width: 100%;
   height: 100%;
 }
@@ -77,4 +77,26 @@
   border-radius: inherit;
   background: rgba(0, 0, 0, 0.08);
   pointer-events: none;
+}
+
+@media (max-width: 767px) {
+  .slot {
+    width: 97.6px;
+    min-height: 100.8px;
+    padding: 7.2px;
+    border-radius: 15.2px;
+    border: 1.9px solid rgba(194, 144, 101, 0.55);
+    box-shadow:
+      inset 0 0 7.7px rgba(0, 0, 0, 0.32),
+      0 5.6px 17.6px rgba(0, 0, 0, 0.26);
+  }
+
+  .slot.is-ally.is-over {
+    box-shadow: 0 0 16px rgba(211, 196, 170, 0.35);
+    transform: translateY(-2.6px);
+  }
+
+  .slot__grid {
+    gap: 5.4px;
+  }
 }

--- a/frontend/src/Components/Init/Init.css
+++ b/frontend/src/Components/Init/Init.css
@@ -134,9 +134,18 @@
 .init-btn-image:active:enabled { transform: translateY(1px); }
 .init-btn-image:disabled { filter: grayscale(40%) opacity(.7); cursor: not-allowed; }
 
-@media (max-width: 420px) {
+@media (max-width: 767px) {
   .init-input { padding-right: 96px; height: 40px; }
   .init-dice  { right: -14px; top: -10px; width: 56px; height: 56px; }
   .init-dice .dice-img { width: 36px; height: 36px; }
   .init-btn-image { width: 240px; height: 66px; }
+
+  .app-bg-image {
+    padding: var(--space-md);
+  }
+
+  .init-logo {
+    width: clamp(210px, 24vw, 280px);
+    height: clamp(210px, 24vw, 280px);
+  }
 }


### PR DESCRIPTION
Card, Energy, Location, Slot 컴포넌트의 CSS에서 사용되던 clamp() 값을 모두 px 고정값으로 변경했습니다.
모바일 환경에서는 @media (max-width: 767px) 미디어 쿼리를 사용해 모바일 전용 크기를 따로 적용했습니다.
추후 게임 레이아웃을 Desktop/Mobile로 분리해 구현할 예정이라, 관련 파일 구조만 임시로 생성해두었습니다. (로직 및 스타일 적용 X)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 스타일

* 게임 카드, 에너지 표시, 위치 카드 및 슬롯의 UI 요소들이 더욱 일관성 있는 크기로 표시됩니다.
* 모바일 디바이스에서 게임플레이 인터페이스의 레이아웃이 개선되어 화면에 최적화되었습니다.
* 게임 보드 및 손패 영역의 시각적 구조가 정리되어 더 나은 사용자 경험을 제공합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->