### PR TITLE
feat: 이동 카드 효과 및 MOVE_CARD 연동 추가

### DIFF
--- a/frontend/src/Components/GamePlay/Card.css
+++ b/frontend/src/Components/GamePlay/Card.css
@@ -13,6 +13,15 @@
   box-shadow: 0 22px 35px rgba(0, 0, 0, 0.35);
 }
 
+.card-undraggable {
+  cursor: not-allowed;
+  opacity: 0.85;
+}
+
+.card-movable {
+  box-shadow: 0 0 0 2px #6dd3ff;
+}
+
 .card-image {
   position: absolute;
   inset: 0px; 
@@ -97,6 +106,21 @@
   line-height: 1.12;
   text-shadow: 0 0 6px rgba(0, 0, 0, 0.6);
   padding-inline: 4px;
+}
+
+.card-move-badge {
+  position: absolute;
+  top: 4px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 174, 255, 0.9);
+  color: #fff;
+  padding: 2px 4px;
+  border-radius: 4px;
+  font-size: 9px;
+  z-index: 7;
+  pointer-events: none;
+  text-shadow: 0 0 4px rgba(0, 0, 0, 0.35);
 }
 
 .enlarged-card-container {

--- a/frontend/src/Components/GamePlay/Card.jsx
+++ b/frontend/src/Components/GamePlay/Card.jsx
@@ -42,6 +42,10 @@ const Card = ({
   onCardClick,
   isDraggable = false,
   isSelected = false,
+  origin = "hand",
+  fromLaneIndex = null,
+  fromSlotIndex = null,
+  isMoveAvailable = false,
 }) => {
   console.log({
     cardId,
@@ -57,14 +61,42 @@ const Card = ({
     updatedAt
   });
     const nameRef = useRef(null);
-    const [{ isDragging }, dragRef] = useDrag(() => ({
-      type: "CARD",
-      item: { cardId, name, imageUrl, cost, power, faction, effectDesc, effect },
-      collect: (monitor) => ({
-        isDragging: monitor.isDragging(),
+    const [{ isDragging }, dragRef] = useDrag(
+      () => ({
+        type: "CARD",
+        item: {
+          cardId,
+          name,
+          imageUrl,
+          cost,
+          power,
+          faction,
+          effectDesc,
+          effect,
+          origin,
+          fromLaneIndex,
+          fromSlotIndex,
+        },
+        collect: (monitor) => ({
+          isDragging: monitor.isDragging(),
+        }),
+        canDrag: () => isDraggable,
       }),
-      canDrag: () => isDraggable, // 드래그 가능 여부 제어
-    }), [cardId, name, imageUrl, cost, power, faction, effectDesc, effect, isDraggable]);
+      [
+        cardId,
+        name,
+        imageUrl,
+        cost,
+        power,
+        faction,
+        effectDesc,
+        effect,
+        origin,
+        fromLaneIndex,
+        fromSlotIndex,
+        isDraggable,
+      ]
+    );
     useEffect(() => {
       const el = nameRef.current;
     if (!el) return;
@@ -80,9 +112,18 @@ const Card = ({
     }
   }, [name]);
   const borderClass = factionClasses[faction] || "card-border-default";
+  const containerClassNames = [
+    "card-container",
+    isDragging ? "card-dragging" : "",
+    isSelected ? "card-selected" : "",
+    isMoveAvailable ? "card-movable" : "",
+    !isDraggable ? "card-undraggable" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
   return (
     <div 
-      className={`card-container ${isDragging ? "card-dragging" : ""} ${isSelected ? "card-selected" : ""}`} 
+      className={containerClassNames}
       ref={isDraggable ? dragRef : null} //드래그 가능 시에만 DnD ref 연결
       onClick={onCardClick}
     >
@@ -99,6 +140,7 @@ const Card = ({
       </div>
 
       <div className="card-name" ref={nameRef}>{name}</div>
+      {isMoveAvailable && <div className="card-move-badge">이동 가능</div>}
     </div>
   );
 };

--- a/frontend/src/Components/GamePlay/Slot.jsx
+++ b/frontend/src/Components/GamePlay/Slot.jsx
@@ -2,18 +2,42 @@ import React, { useMemo } from "react";
 import { useDrop } from "react-dnd";
 import "./Slot.css";
 import Card from "./Card";
+import { canMoveCard, isMoveLimitedPerTurn } from "./utils/effect";
 
-
-export default function Slot({ isMySide = false, laneIndex, onDropCard, disabled = false, cards = [null, null, null, null] }) {
+export default function Slot({
+  isMySide = false,
+  laneIndex,
+  onDropCard,
+  disabled = false,
+  cards = [null, null, null, null],
+  movedThisTurnMap = {},
+  currentTurn = 1,
+}) {
   const firstEmpty = useMemo(() => cards.findIndex((c) => !c), [cards]); //cards 배열에서 첫 번째 빈 칸의 인덱스 찾기
   const isFull = firstEmpty === -1;
   const allowDrop = isMySide && !disabled && !isFull;
 
   const [{ isOver }, dropRef] = useDrop({
     accept: "CARD",
-    canDrop: () => allowDrop,
+    canDrop: (item) => {
+      if (!allowDrop) return false;
+      if (item?.origin === "board") {
+        if (item.fromLaneIndex === laneIndex) return false; // 같은 지역으로 이동 방지
+        if (!canMoveCard(item)) return false;
+
+        const limited = isMoveLimitedPerTurn(item);
+        if (limited && movedThisTurnMap[item.cardId] === currentTurn) return false;
+      }
+      return true;
+    },
     drop: (item) => {
-      onDropCard?.({ laneIndex, card: item });
+      onDropCard?.({
+        laneIndex,
+        card: item,
+        fromLaneIndex: item.fromLaneIndex,
+        fromSlotIndex: item.fromSlotIndex,
+        origin: item.origin,
+      });
       return { moved: true };
     },
     collect: (monitor) => ({
@@ -47,8 +71,22 @@ export default function Slot({ isMySide = false, laneIndex, onDropCard, disabled
                 active={card.active}
                 createdAt={card.createdAt}
                 updatedAt={card.updatedAt}
+                origin="board"
+                fromLaneIndex={laneIndex}
+                fromSlotIndex={i}
                 onCardClick={() => {}}
-                isDraggable={false}
+                isDraggable={
+                  isMySide &&
+                  !disabled &&
+                  canMoveCard(card) &&
+                  !(isMoveLimitedPerTurn(card) && movedThisTurnMap[card.cardId] === currentTurn)
+                }
+                isMoveAvailable={
+                  isMySide &&
+                  !disabled &&
+                  canMoveCard(card) &&
+                  !(isMoveLimitedPerTurn(card) && movedThisTurnMap[card.cardId] === currentTurn)
+                }
               />
             )}
           </div>

--- a/frontend/src/Components/GamePlay/utils/effect.js
+++ b/frontend/src/Components/GamePlay/utils/effect.js
@@ -1,0 +1,39 @@
+export function parseEffect(effectRaw) {
+  if (!effectRaw) return null;
+
+  if (typeof effectRaw === "string") {
+    try {
+      return JSON.parse(effectRaw);
+    } catch (error) {
+      console.warn("[parseEffect] JSON 파싱 실패", error, effectRaw);
+      return null;
+    }
+  }
+
+  if (Array.isArray(effectRaw) || typeof effectRaw === "object") {
+    return effectRaw;
+  }
+
+  return null;
+}
+
+function normalizeEffects(effectRaw) {
+  const parsed = parseEffect(effectRaw);
+  if (!parsed) return [];
+
+  return Array.isArray(parsed) ? parsed : [parsed];
+}
+
+export function getMoveEffects(card) {
+  return normalizeEffects(card?.effect).filter(
+    (eff) => eff && eff.action === "enable_move"
+  );
+}
+
+export function canMoveCard(card) {
+  return getMoveEffects(card).length > 0;
+}
+
+export function isMoveLimitedPerTurn(card) {
+  return getMoveEffects(card).some((eff) => eff?.value === "per_turn");
+}


### PR DESCRIPTION
- effect 문자열/객체 안전 파싱 유틸(parseEffect) 추가
- enable_move 포함 여부로 이동 가능 카드 판별, per_turn 제한 식별
- movedThisTurn으로 턴 당 1회 이동 제한(턴 변경 시 리셋)
- 이동 성공 시 낙관적 업데이트 후 playAction(MOVE_CARD) 호출

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 게임 보드에서 카드를 드래그하여 이동할 수 있는 기능 추가
  * 이동 가능한 카드에 시각적 표시(배지 및 아웃라인) 추가
  * 턴당 카드 이동 횟수 제한 기능 적용
  * 카드 드래그 시 이동 불가능한 카드에 대해 명확한 시각적 피드백 제공

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->