### PR TITLE
fix(cardEffect, back): 카드 효과 완성

### DIFF
--- a/frontend/src/Components/GamePlay/GameLayout.jsx
+++ b/frontend/src/Components/GamePlay/GameLayout.jsx
@@ -152,7 +152,7 @@ export default function GameLayout({ matchId }) {
         const mapped = cards.map(item => ({
           cardId: item.cardId,
           name: item.name,
-          imageUrl: item.imageUrl || DCI,
+          imageUrl: item.imageUrl || defaultImg,
           cost: item.cost,
           power: item.power,
           faction: item.faction,


### PR DESCRIPTION
#105 
한국, 일본 중국 카드 효과 완성

각 덱을 하드코딩해서 효과를 적용시키자는 말이 있었지만 그냥 json만 형식에 맞추면 자동으로 효과가 적용될 수 있게 함.

추가 이슈: 일본 덱의 닌자의 효과를 구현할 때 이동하면 move_card로 받아서 play엔티티를 하나 더 만들고 전체 play를 더해서 지역에 반영시키니 이런 이슈가 있었음.
닌자 지역 1에 배치 => 지역 파워: 3, 0, 0
닌자 지역 2로 이동 => 지역 파워: 3, 3, 5(카구야의 효과로 인한 지역 3의 5는 정상)
이 이유는 모든 play를 더하기에 새로 만든 play, 기존 play가 겹치기 떄문임.
추가 해결: 기존 play를 삭제하면 이동했는지에 대한 여부를 알 수 없기에 가장 간단하게 기존 play의 파워를 0으로 수정할 수 있게 함. 따라서
닌자 지역 1에 배치 => 지역 파워: 3, 0, 0
닌자 지역 2로 이동 => 지역 파워: 0, 3, 5(카구야의 효과로 인한 지역 3의 5는 정상)
이렇게 정상적으로 작동함.
<img width="1014" height="361" alt="스크린샷 2025-11-22 171852" src="https://github.com/user-attachments/assets/7d7133d1-91cc-4dbb-a053-448b6d5c001c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 카드 이동 기능 추가 - 게임 중 카드 위치 이동 시스템 구현
  * 지속 효과 즉시 처리 - 카드 배치 시 게임 효과 실시간 적용

* **Bug Fixes**
  * 덱 카드 이미지 표시 개선 - 카드 이미지 로드 실패 시 대체 이미지 적용

* **Refactor**
  * 게임 효과 계산 로직 정리 - 파워 계산 프로세스 최적화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->