### PR TITLE
fix(china, cardEffect, back): 타겟 카드 수를 세어 곱하게 하여 해결하였습니다.

### DIFF
--- a/backend/src/main/java/com/snaptale/backend/match/service/TurnService.java
+++ b/backend/src/main/java/com/snaptale/backend/match/service/TurnService.java
@@ -504,7 +504,8 @@ public class TurnService {
 
                 if (allCardsPresent) {
                     try {
-                        int bonus = Integer.parseInt(effect.getValue().trim());
+                        int cardsPresentCount = presentCardNames.size();
+                        int bonus = cardsPresentCount * Integer.parseInt(effect.getValue().trim());
                         log.info(
                                 "power_if_cards_present 효과 즉시 적용: cardName={}, slotIndex={}, requiredCards={}, bonus={}",
                                 card.getName(), slotIndex, requiredCardNames, bonus);


### PR DESCRIPTION
#124 
카드 수를 세어 그대로 곱해주면 해결할 수 있습니다. 정상적으로 +6이 추가됩니다.
<img width="137" height="279" alt="image" src="https://github.com/user-attachments/assets/b4f4b84d-45b9-4876-8547-f25840b998ac" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **게임플레이 개선**
  * 특정 카드 존재 조건의 보너스 계산이 이제 동일 슬롯에 있는 카드의 개수에 따라 동적으로 조정됩니다. 카드가 많을수록 더 높은 보너스를 받게 되어 전략적 깊이가 증가합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->