### PR TITLE
fix : 초기 에너지 = 1로 수정 - 로직 개선 필요

### DIFF
--- a/backend/src/main/java/com/snaptale/backend/match/service/GameFlowService.java
+++ b/backend/src/main/java/com/snaptale/backend/match/service/GameFlowService.java
@@ -32,7 +32,7 @@ public class GameFlowService {
     private final MatchParticipantRepository matchParticipantRepository;
     private final MatchLocationRepository matchLocationRepository;
     private final MatchLocationService matchLocationService;
-    private static final int INITIAL_ENERGY = 100;
+    private static final int INITIAL_ENERGY = 1;
     private static final int ENERGY_PER_TURN = 1;
 
     // 게임 시작 (턴 카운트를 1로 설정하고 상태를 PLAYING으로 변경)


### PR DESCRIPTION
실제 게임과 같이 초기에너지 = 1로 시작하게 하였으나, 에너지 처리 정책이 맞지 않아 수정필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **게임 플레이**
  * 게임 시작 시 모든 참가자에게 할당되는 초기 에너지 값이 100에서 1로 변경되었습니다. 이 변경은 게임 시작 단계에서만 영향을 미칩니다. 턴 진행, 매 턴 에너지 충전, 카드 드로우, 게임 흐름 및 사용자 인터페이스는 정상 작동합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->