### PR TITLE
fix: '닌자' 분신술 버그 수정

### DIFF
--- a/backend/src/main/java/com/snaptale/backend/match/repository/PlayRepository.java
+++ b/backend/src/main/java/com/snaptale/backend/match/repository/PlayRepository.java
@@ -53,4 +53,9 @@ public interface PlayRepository extends JpaRepository<Play, Long> {
         Integer sumPowerSnapshotByMatchAndGuestIdAndSlotIndex(@Param("matchId") Long matchId,
                         @Param("guestId") Long guestId,
                         @Param("slotIndex") Integer slotIndex);
+
+        // 보드에 노출되어야 하는 최신 플레이 조회 (이동으로 파워가 0이 된 기록 제외)
+        @Query("SELECT p FROM Play p WHERE p.match.matchId = :matchId " +
+                "AND p.guestId = :guestId AND (p.isTurnEnd = false OR COALESCE(p.powerSnapshot, 0) > 0)")
+        List<Play> findActiveByMatchIdAndGuestId(@Param("matchId") Long matchId, @Param("guestId") Long guestId);
 }

--- a/backend/src/main/java/com/snaptale/backend/match/service/TurnService.java
+++ b/backend/src/main/java/com/snaptale/backend/match/service/TurnService.java
@@ -277,6 +277,7 @@ public class TurnService {
         // 6. 이전 슬롯의 Play 파워를 0으로 설정 (중복 파워 계산 방지)
         // Play 자체는 유지하여 이동 이력을 추적할 수 있도록 함
         previousPlay.setPowerSnapshot(0);
+        previousPlay.setIsTurnEnd(true);
         playRepository.save(previousPlay);
 
         log.info(

--- a/backend/src/main/java/com/snaptale/backend/match/websocket/service/MatchWebSocketService.java
+++ b/backend/src/main/java/com/snaptale/backend/match/websocket/service/MatchWebSocketService.java
@@ -26,11 +26,8 @@ import org.springframework.transaction.annotation.Transactional;
 import com.snaptale.backend.match.model.request.MatchUpdateReq;
 
 import java.time.LocalDateTime;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 // Match 도메인 WebSocket 비즈니스 로직 처리
@@ -255,11 +252,18 @@ public class MatchWebSocketService {
 		// 각 플레이어의 카드 배치 정보 수집
 		Map<Long, List<TurnStatusMessage.CardPlayInfo>> playerCardPlays = new HashMap<>();
 		for (MatchParticipant participant : participants) {
-			List<Play> plays = playRepository.findByMatch_MatchIdAndGuestId(matchId, participant.getGuestId());
+			List<Play> plays = playRepository.findActiveByMatchIdAndGuestId(matchId, participant.getGuestId());
 
-			// isTurnEnd가 false인 플레이만 필터링 (실제 카드 플레이)
-			List<TurnStatusMessage.CardPlayInfo> cardPlays = plays.stream()
-					.filter(play -> !play.getIsTurnEnd() && play.getCard() != null)
+			// 동일 카드에 대한 최신 이동 기록만 유지
+			Map<Long, Play> latestPlaysByCard = plays.stream()
+					.filter(play -> play.getCard() != null)
+					.filter(this::isActiveBoardPlay)
+					.collect(Collectors.toMap(
+							play -> play.getCard().getCardId(),
+							Function.identity(),
+							this::selectLatestPlay));
+
+			List<TurnStatusMessage.CardPlayInfo> cardPlays = latestPlaysByCard.values().stream()
 					.map(play -> TurnStatusMessage.CardPlayInfo.builder()
 							.cardId(play.getCard().getCardId())
 							.cardName(play.getCard().getName())
@@ -288,6 +292,18 @@ public class MatchWebSocketService {
 				.build();
 
 		broadcastToMatch(matchId, "TURN_START", payload, "턴 " + turnResult.getNextTurn() + "이 시작되었습니다.");
+	}
+
+	private boolean isActiveBoardPlay(Play play) {
+		int powerSnapshot = Optional.ofNullable(play.getPowerSnapshot()).orElse(0);
+		return !Boolean.TRUE.equals(play.getIsTurnEnd()) || powerSnapshot > 0;
+	}
+
+	private Play selectLatestPlay(Play existing, Play candidate) {
+		Comparator<Play> playRecencyComparator = Comparator.comparing(Play::getTurnCount)
+				.thenComparing(Play::getId);
+
+		return playRecencyComparator.compare(existing, candidate) >= 0 ? existing : candidate;
 	}
 
 	// 매치 채팅 처리


### PR DESCRIPTION
`moveCard`에서 이전 `Play`를 찾은 뒤 `setIsTurnEnd(true)` 또는 별도 상태 플래그를 설정해 더 이상 보드 스냅샷에 포함되지 않도록 처리함.

closes #128

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 게임 카드 이동 정보 표시가 개선되었습니다. 이제 각 카드의 최신 활성 이동만 정확하게 표시됩니다.
  * 턴 상태 추적이 강화되어 게임 플레이 기록의 정확성이 향상되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->