### PR TITLE
fix: slot_cell의object_fit을 cover로 수정

### DIFF
--- a/frontend/src/Components/GamePlay/Slot.css
+++ b/frontend/src/Components/GamePlay/Slot.css
@@ -66,7 +66,7 @@
 }
 
 .slot__cell .card-image {
-  object-fit: contain;
+  object-fit: cover;
 }
 
 /* 상대편 슬롯에 드롭 금지 시 시각적 잠금 표시(이벤트 차단 안 함) */
@@ -123,7 +123,7 @@
     width: 100%;
     height: 100%;
     inset: 0;
-    object-fit: contain;
+    object-fit: cover;
   }
 
   .slot__cell .card-cost-container,


### PR DESCRIPTION
Closes #134
<img width="820" height="417" alt="image" src="https://github.com/user-attachments/assets/4384b07a-3995-439a-b702-5616e678b5d4" /> <br>
원본 카드의 비율이 1대1인 카드들은 배치되었을 때 정사각형으로 표시됨.
이유는 .slot__cell .card-image 의 object-fit이 contain이었기 때문
`.slot__cell .card-image {
  object-fit: contain;
}`
object-fit: cover;로 바꾸니까
<img width="1586" height="862" alt="image" src="https://github.com/user-attachments/assets/becffd4a-8eea-40a5-8dc0-d6b553a78b9f" /> <br>
<img width="1585" height="882" alt="image" src="https://github.com/user-attachments/assets/cc74e465-513f-45d0-8b4b-fb827568aaad" /> <br>
다른 카드도 다 잘 표시됩니다.

