### PR TITLE
fix: TurnStatusMessage에 effect와 effect_desc 필드도 같이 전송하도록 수정

### DIFF
--- a/backend/src/main/java/com/snaptale/backend/match/service/GameFlowService.java
+++ b/backend/src/main/java/com/snaptale/backend/match/service/GameFlowService.java
@@ -32,7 +32,7 @@ public class GameFlowService {
     private final MatchParticipantRepository matchParticipantRepository;
     private final MatchLocationRepository matchLocationRepository;
     private final MatchLocationService matchLocationService;
-    private static final int INITIAL_ENERGY = 1;
+    private static final int INITIAL_ENERGY = 2;
 
     // 게임 시작 (턴 카운트를 1로 설정하고 상태를 PLAYING으로 변경)
     @Transactional
@@ -101,8 +101,9 @@ public class GameFlowService {
         // 모든 플레이어에게 턴 수에 맞는 에너지 설정 및 다음 턴 에너지 보너스 적용
         List<MatchParticipant> participants = matchParticipantRepository.findByMatch_MatchId(matchId);
         for (MatchParticipant participant : participants) {
+            int baseEnergy = INITIAL_ENERGY + (nextTurn - 1);
             // 턴 수에 맞는 에너지로 설정 (1턴 = 1, 2턴 = 2, 3턴 = 3)
-            participant.setEnergy(nextTurn);
+            participant.setEnergy(baseEnergy);
             // 다음 턴 에너지 보너스 적용
             participant.applyNextTurnEnergyBonus();
             matchParticipantRepository.save(participant);

--- a/backend/src/main/java/com/snaptale/backend/match/websocket/message/TurnStatusMessage.java
+++ b/backend/src/main/java/com/snaptale/backend/match/websocket/message/TurnStatusMessage.java
@@ -42,5 +42,7 @@ public class TurnStatusMessage {
         private Integer cost; // 카드 코스트
         private Integer power;
         private String faction;
+        private String effect_desc;
+        private String effect;
     }
 }

--- a/backend/src/main/java/com/snaptale/backend/match/websocket/service/MatchWebSocketService.java
+++ b/backend/src/main/java/com/snaptale/backend/match/websocket/service/MatchWebSocketService.java
@@ -243,6 +243,8 @@ public class MatchWebSocketService {
 							.cost(play.getCard().getCost())
 							.power(play.getPowerSnapshot())
 							.faction(play.getCard().getFaction())
+							.effect_desc(play.getCard().getEffectDesc())
+							.effect(play.getCard().getEffect())
 							.build())
 					.toList();
 
@@ -298,6 +300,8 @@ public class MatchWebSocketService {
 							.cost(play.getCard().getCost())
 							.power(play.getPowerSnapshot())
 							.faction(play.getCard().getFaction())
+							.effect_desc(play.getCard().getEffectDesc())
+							.effect(play.getCard().getEffect())
 							.build())
 					.toList();
 


### PR DESCRIPTION
프론트에서 카드를 내고, 파워 등의 변화가 있을 때도 정보를 새로 가져오도록 하는 TurnStatusMessage에 카드 효과와 닌자의 이동 효과를 추적하는 effect 필드도 포함해서 전달하도록 수정함.

<img width="1748" height="902" alt="KakaoTalk_20251127_154053516" src="https://github.com/user-attachments/assets/3d2ef35d-6417-42fd-8046-579d4f8e7f65" />

close #138


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 카드 효과 설명이 게임 메시지에 추가되어 카드 플레이 정보를 더 자세히 확인할 수 있습니다.

* **게임 밸런스**
  * 턴 진행에 따른 에너지 계산 방식이 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->